### PR TITLE
Add @objc attributes for Swift 4 compatibility

### DIFF
--- a/Pod/Classes/AZDropdownMenu.swift
+++ b/Pod/Classes/AZDropdownMenu.swift
@@ -250,7 +250,7 @@ open class AZDropdownMenu: UIView {
         )
     }
 
-    func overlayTapped() {
+    @objc func overlayTapped() {
         hideMenu()
     }
 
@@ -384,7 +384,7 @@ extension AZDropdownMenu: UITableViewDelegate {
 // MARK: - UIGestureRecognizerDelegate
 extension AZDropdownMenu: UIGestureRecognizerDelegate {
 
-    public func handlePan(gestureRecognizer: UIPanGestureRecognizer) {
+    @objc public func handlePan(gestureRecognizer: UIPanGestureRecognizer) {
         guard self.shouldDismissMenuOnDrag == true else {
             return
         }


### PR DESCRIPTION
### Description
Swift 4 requires the `@objc` attribute on any function referenced by `#selector`.  This pull request adds that attribute to two functions.

#### Fix
- Swift 4 compatibility
